### PR TITLE
fixbug: not found style.min.css in drone-plugin-index

### DIFF
--- a/static/dist/style.min.css
+++ b/static/dist/style.min.css
@@ -1,0 +1,1099 @@
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+}
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
+}
+body {
+  line-height: 1;
+}
+ol,
+ul {
+  list-style: none;
+}
+blockquote,
+q {
+  quotes: none;
+}
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: '';
+  content: none;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+/*
+
+github.com style (c) Vasily Polovnyov <vast@whiteants.net>
+
+*/
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  color: #333;
+  background: #f8f8f8;
+  background: #eeeeee;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #998;
+  font-style: italic;
+}
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-subst {
+  color: #333;
+  font-weight: bold;
+}
+.hljs-number,
+.hljs-literal,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-tag .hljs-attr {
+  color: #008080;
+}
+.hljs-string,
+.hljs-doctag {
+  color: #d14;
+}
+.hljs-title,
+.hljs-section,
+.hljs-selector-id {
+  color: #900;
+  font-weight: bold;
+}
+.hljs-subst {
+  font-weight: normal;
+}
+.hljs-type,
+.hljs-class .hljs-title {
+  color: #458;
+  font-weight: bold;
+}
+.hljs-tag,
+.hljs-name,
+.hljs-attribute {
+  color: #000080;
+  font-weight: normal;
+}
+.hljs-regexp,
+.hljs-link {
+  color: #009926;
+}
+.hljs-symbol,
+.hljs-bullet {
+  color: #990073;
+}
+.hljs-built_in,
+.hljs-builtin-name {
+  color: #0086b3;
+}
+.hljs-meta {
+  color: #999;
+  font-weight: bold;
+}
+.hljs-deletion {
+  background: #fdd;
+}
+.hljs-addition {
+  background: #dfd;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+/* Hljs adjustment */
+.hljs {
+  overflow-x: visible;
+}
+/* Yaml adjustments */
+.hljs.language-yaml .hljs-attr {
+  color: #458;
+}
+/* Go adjustments */
+.hljs.language-Go .hljs-keyword {
+  color: #458;
+  font-weight: normal;
+}
+.hljs.language-Go .hljs-title {
+  font-weight: normal;
+}
+/* Dockerfile adjustments */
+.hljs.language-dockerfile .hljs-keyword {
+  color: #458;
+  font-weight: normal;
+}
+/* Bash adjustments */
+.hljs.language-sh .hljs-meta {
+  color: #999;
+  font-weight: normal;
+}
+/* Diff adjustments */
+.hljs.language-diff .hljs-addition {
+  background: #A7FFEB;
+}
+.hljs.language-diff .hljs-deletion {
+  background: #FCE4EC;
+}
+aside {
+  position: fixed;
+  overflow-y: auto;
+  right: 0px;
+  top: 0px;
+  width: 350px;
+  bottom: 0px;
+  z-index: 1;
+  background: #FFF;
+  border-left: 1px solid #EEE;
+  box-shadow: -3px 10px 10px rgba(0, 0, 0, 0.3);
+  text-align: left;
+  display: none;
+}
+aside nav {
+  padding: 20px 0px;
+}
+aside a {
+  display: block;
+  padding: 0px 30px;
+  line-height: 32px;
+  color: #000;
+  text-decoration: none;
+}
+aside a:hover {
+  color: #00BFA5;
+}
+aside h3 {
+  border-top: 1px solid #EEE;
+  margin: 30px 0px;
+  margin-bottom: 10px;
+  padding: 0px 30px;
+  padding-top: 20px;
+  line-height: 32px;
+  font-size: 14px;
+  color: #9E9E9E;
+  text-transform: uppercase;
+}
+@media (max-width: 450px) {
+  aside {
+    width: 80%;
+    min-width: 80%;
+  }
+}
+.overlay {
+  display: none;
+  position: fixed;
+  top: 0px;
+  bottom: 0px;
+  right: 0px;
+  left: 0px;
+  background: rgba(0, 0, 0, 0.2);
+  z-index: 1;
+}
+#drawer-toggle:checked ~ #drawer-toggle-label {
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  z-index: 1;
+  background: rgba(0, 0, 0, 0.5);
+}
+.projects,
+.plugins {
+  display: flex;
+  flex-wrap: wrap;
+}
+@media (max-width: 800px) {
+  .projects,
+  .plugins {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+}
+.projects > article,
+.plugins > article {
+  border: none !important;
+  padding: 0px !important;
+  margin: 0px !important;
+  width: 50%;
+}
+@media (max-width: 800px) {
+  .projects > article,
+  .plugins > article {
+    width: 100%;
+  }
+}
+.projects > article > div,
+.plugins > article > div {
+  border: 1px solid #EEE;
+  border-radius: 2px;
+  margin-bottom: 20px;
+  padding: 30px;
+  min-height: 110px;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+.projects > article > div .logo,
+.plugins > article > div .logo {
+  background-repeat: no-repeat;
+  background-size: contain;
+  background-position: center center;
+  width: 64px;
+  height: 64px;
+  position: absolute;
+  top: 20px;
+  right: 30px;
+}
+.projects > article > div h2,
+.plugins > article > div h2 {
+  flex: 1 1 auto;
+  padding-right: 75px;
+  line-height: 22px;
+}
+.projects > article .tags,
+.plugins > article .tags {
+  display: block;
+  margin-left: 0px;
+  margin-top: 10px;
+}
+.projects > article .tags li:first-child .tag,
+.plugins > article .tags li:first-child .tag {
+  margin-left: 0px;
+}
+.projects > article:nth-child(odd) > div,
+.plugins > article:nth-child(odd) > div {
+  margin-right: 10px;
+}
+.projects > article:nth-child(even) > div,
+.plugins > article:nth-child(even) > div {
+  margin-left: 10px;
+}
+@media (max-width: 800px) {
+  .projects > article > div,
+  .plugins > article > div {
+    margin-left: 0px !important;
+    margin-right: 0px !important;
+  }
+}
+.cards {
+  max-width: 700px;
+  margin: 60px auto;
+  display: flex;
+  flex-wrap: wrap;
+}
+@media (max-width: 800px) {
+  .cards {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+}
+.card {
+  padding: 0px;
+  margin: 0px;
+  width: 50%;
+  margin-bottom: 20px;
+  text-decoration: none;
+  display: block;
+}
+.card .card-inner {
+  padding: 30px;
+  border: 1px solid #EEE;
+  text-decoration: none;
+  display: block;
+}
+.card a.card-inner:hover {
+  border-color: #00BFA5;
+}
+.card:nth-child(odd) .card-inner {
+  margin-right: 10px;
+}
+.card:nth-child(even) .card-inner {
+  margin-left: 10px;
+}
+@media (max-width: 600px) {
+  .card {
+    width: 100%;
+  }
+}
+.card h2 {
+  color: #000;
+  font-size: 22px;
+  text-align: center;
+}
+.card p {
+  margin: 10px 0px;
+  margin-bottom: 0px;
+  line-height: 22px;
+  text-align: center;
+  font-size: 15px;
+  color: #999;
+}
+.card .icon-api {
+  background-image: url("../icon_api.svg");
+}
+.card .icon-doc {
+  background-image: url("../icon_doc.svg");
+}
+.card .icon-install {
+  background-image: url("../icon_install.svg");
+}
+.card .icon-plugin {
+  background-image: url("../icon_plugin.svg");
+}
+.card .icon {
+  height: 128px;
+  background-size: 112px;
+  background-repeat: no-repeat;
+  background-position: center;
+  margin: 10px 0px;
+}
+.endpoint {
+  background: #f5f5f5;
+  color: #999;
+  white-space: nowrap;
+  margin: 0px 2px;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 14px;
+  padding: 5px 10px;
+  font-family: monospace;
+}
+.filter {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background: #f5f5f5;
+  padding: 0px;
+  margin: 0px;
+  margin-bottom: 40px;
+}
+.filter .filter-inner {
+  padding: 25px;
+  color: #999;
+  font-size: 16px;
+  text-transform: uppercase;
+  white-space: nowrap;
+  margin: 0px auto;
+  max-width: 800px;
+}
+@media (max-width: 800px) {
+  .filter .filter-inner {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+}
+.filter span {
+  line-height: 24px;
+  vertical-align: middle;
+  font-size: 20px;
+  margin-left: 20px;
+}
+footer {
+  margin: 0px;
+  padding: 60px 20px 30px 20px;
+  background-color: #37474F;
+  text-align: center;
+}
+footer ul {
+  max-width: 650px;
+  margin: 0px auto;
+  margin-top: 20px;
+  text-align: center;
+}
+footer ul li {
+  display: inline-block;
+  margin-bottom: 7px;
+}
+footer ul li:last-child a:after {
+  display: none;
+}
+footer ul a {
+  color: #f5f5f5;
+  text-decoration: none;
+  display: inline-block;
+  padding: 0px 10px 0px 0px;
+  font-size: 14px;
+}
+footer ul a:after {
+  color: #607D8B;
+  content: "|";
+  padding-left: 10px;
+}
+footer p {
+  color: #607D8B;
+  font-size: 14px;
+}
+.infobar,
+.infobar-language {
+  text-align: center;
+  text-decoration: none;
+  padding: 20px;
+  background: #FFECB3;
+  color: #FF8F00;
+  display: block;
+}
+.infobar a,
+.infobar-language a {
+  color: #FF8F00;
+  text-decoration: none;
+}
+.infobar[hidden],
+.infobar-language[hidden] {
+  display: none;
+}
+.infobar-language {
+  border-bottom: 1px solid #FFE082;
+}
+.infobar-stackoverflow {
+  text-decoration: none;
+  display: block;
+  padding: 0px 20px;
+}
+.infobar-stackoverflow span {
+  line-height: 72px;
+  display: inline-block;
+  padding-right: 46px;
+  font-size: 18px;
+  white-space: nowrap;
+  background-size: 32px;
+  background-image: url("../stackoverflow.svg");
+  background-repeat: no-repeat;
+  background-position: right center;
+  margin: 0px 20px;
+}
+.cta {
+  background: #ECEFF1;
+  height: 100px;
+}
+.cta div {
+  max-width: 800px;
+  margin: 0px auto;
+  line-height: 100px;
+  font-size: 22px;
+  color: #455A64;
+  text-align: center;
+}
+.cta a {
+  border: 2px solid #00BFA5;
+  color: #00BFA5;
+  text-decoration: none;
+  padding: 5px 10px;
+  margin-right: 10px;
+  border-radius: 2px;
+}
+menu {
+  padding: 0px;
+  margin: 0 auto;
+  margin-top: 40px;
+  margin-bottom: 20px;
+  text-align: right;
+  max-width: 800px;
+}
+menu a {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  text-decoration: none;
+  background: #00BFA5;
+  font-weight: 400;
+  padding: 10px 20px;
+  border-radius: 2px;
+  color: #FFF;
+  display: inline-block;
+  cursor: pointer;
+}
+@media (max-width: 800px) {
+  menu {
+    padding: 0px 20px;
+  }
+}
+html,
+body {
+  font-family: Roboto;
+  font-weight: 400;
+  min-height: 100%;
+  min-width: 100%;
+}
+body > header {
+  margin: 0px;
+  padding: 0px;
+  background: #37474F;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+body > header > nav {
+  display: block;
+  box-sizing: border-box;
+  background: url(../logo.svg);
+  background-size: 42px;
+  background-position: 15px 15px;
+  background-repeat-x: no-repeat;
+  background-repeat-y: no-repeat;
+  background-repeat: no-repeat;
+  padding-left: 68px;
+  text-align: right;
+  padding-right: 40px;
+}
+@media (max-width: 800px) {
+  body > header > nav {
+    padding: 20px;
+  }
+  body > header > nav > a {
+    line-height: 36px !important;
+    display: block !important;
+  }
+}
+body > header > nav > a {
+  color: rgba(255, 255, 255, 0.6);
+  text-decoration: none;
+  font-weight: 400;
+  font-size: 16px;
+  margin-left: 6px;
+  line-height: 70px;
+  display: inline-block;
+  padding: 0px 3px;
+}
+body > header > nav > a.selected {
+  color: #FFF;
+}
+body > header > nav > a:hover,
+body > header > nav > a:selected,
+body > header > nav > a:selected:hover {
+  color: #FFF;
+}
+section {
+  margin: 0px auto;
+  margin-top: 40px;
+  margin-bottom: 40px;
+  max-width: 800px;
+}
+.list section {
+  margin-top: 20px;
+}
+.list section article {
+  padding: 30px 20px;
+  border-top: 1px solid #EEE;
+}
+.list.taxonomy section article:first-child {
+  border: none;
+}
+section article h2 a {
+  color: #000;
+  text-decoration: none;
+  font-weight: 400;
+  font-size: 22px;
+}
+section article h2 a:hover {
+  color: #00BFA5;
+}
+section article h2 {
+  margin: 0px;
+  margin-bottom: 12px;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+main header {
+  margin: 0px;
+  padding: 0px;
+  background-color: #37474F;
+}
+main header div {
+  max-width: 800px;
+  margin: 0px auto;
+  padding: 0px;
+  padding-top: 35px;
+  padding-bottom: 40px;
+}
+@media (max-width: 800px) {
+  main header div {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+  main header div input {
+    display: none;
+  }
+}
+main header h1 {
+  font-weight: 300;
+  font-size: 46px;
+  line-height: 70px;
+  color: #fff;
+  text-align: center;
+  margin: 0px;
+  letter-spacing: 0.5px;
+  user-select: none;
+  -webkit-user-select: none;
+}
+main header input {
+  border: 0;
+  font-size: 18px;
+  font-weight: 400;
+  padding: 18px;
+  border-radius: 3px;
+  display: block;
+  color: rgba(0, 0, 0, 0.7);
+  width: 100%;
+  box-sizing: border-box;
+  outline: none;
+  font-family: Roboto;
+}
+main header p {
+  color: #FFF;
+  text-align: center;
+  max-width: 500px;
+  margin: 0px auto;
+  line-height: 25px;
+  font-size: 18px;
+  font-weight: 300;
+  margin-bottom: 40px;
+  user-select: none;
+  -webkit-user-select: none;
+}
+::-webkit-input-placeholder {
+  color: rgba(0, 0, 0, 0.3);
+  font-weight: 400;
+}
+.tags {
+  display: inline-block;
+  list-style: none;
+  margin: 0px;
+  padding: 0px;
+}
+.tags li {
+  display: inline-block;
+}
+.tag {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background: #f5f5f5;
+  color: #999;
+  text-transform: uppercase;
+  white-space: nowrap;
+  margin: 0px 2px;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 12px;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+.tag:hover {
+  color: #00BFA5;
+}
+.author {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  color: #999;
+  font-weight: 400;
+  margin-right: 5px;
+  font-size: 15px;
+}
+.single main header {
+  background: #FFF;
+  border-bottom: 1px solid #E5E5E5;
+}
+.single main header div {
+  margin: 0px auto;
+  max-width: 800px;
+  padding: 40px 0px;
+}
+@media (max-width: 800px) {
+  .single main header div {
+    padding: 20px;
+  }
+}
+.single main header h1 {
+  color: #000;
+  text-align: left;
+  font-size: 30px;
+  font-weight: 400;
+  line-height: 36px;
+  margin: 0px;
+  margin-bottom: 5px;
+}
+.single main header p {
+  margin: 0px;
+  padding: 0px;
+  color: #000;
+  text-align: left;
+  font-size: 16px;
+  font-weight: 400;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.alert {
+  background: #e3f8ff;
+  color: #00b0e9;
+  padding: 20px;
+  margin: 30px 0px;
+}
+.alert:before {
+  font-family: 'Material Icons';
+  font-weight: 400;
+  font-style: normal;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  word-wrap: normal;
+  -moz-font-feature-settings: 'liga';
+  font-feature-settings: 'liga';
+  -webkit-font-feature-settings: 'liga';
+  -webkit-font-smoothing: antialiased;
+  content: 'lightbulb_outline';
+  float: left;
+}
+.alert p {
+  padding: 0px;
+  margin: 0px !important;
+  font-size: 15px !important;
+  padding-top: 0px;
+  padding-left: 40px;
+  font-weight: 400;
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
+}
+.alert.alert-warn {
+  background: #FFECB3;
+  color: #FF8F00;
+}
+.alert.alert-warn:before {
+  content: 'error_outline';
+}
+.alert.alert-warn a {
+  color: #FF8F00 !important;
+  text-decoration: underline;
+}
+.alert.alert-error {
+  background: #ffe3eb;
+  color: #e80044;
+}
+.alert.alert-error:before {
+  content: 'error_outline';
+}
+.alert.alert-error a {
+  color: #e80044 !important;
+  text-decoration: underline;
+}
+.alert a {
+  color: #00b0e9 !important;
+  text-decoration: underline !important;
+}
+#markdown > .alert:first-child {
+  margin-top: 0px;
+}
+#markdown > .alert p code {
+  border: none;
+  font-size: 15px;
+  line-height: 21px;
+  display: inline-block;
+  background: rgba(0, 176, 233, 0.09);
+}
+#markdown {
+  font-size: 16px;
+  line-height: 24px;
+}
+#markdown ol,
+#markdown ul {
+  margin: 30px 0px;
+  margin-left: 20px;
+  list-style: disc;
+}
+#markdown p {
+  margin-bottom: 30px;
+}
+#markdown p > code,
+#markdown li > code,
+#markdown td > code,
+#markdown dd > code {
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
+  font-size: 14px;
+  background: rgba(236, 239, 241, 0.7);
+  border-radius: 3px;
+  padding: 0px 5px;
+  font-family: monospace;
+  border: 1px solid #ECEFF1;
+  line-height: 18px;
+}
+#markdown table {
+  width: 100%;
+  margin: 30px 0px;
+  border-collapse: collapse;
+  border: 1px solid #eee;
+}
+#markdown table th,
+#markdown table td {
+  text-align: left;
+  padding: 8px;
+  border: 1px solid #eee;
+}
+#markdown table th {
+  padding-left: 10px;
+  font-weight: 700;
+}
+#markdown dl {
+  margin-top: 30px;
+}
+#markdown dl dt {
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
+  font-size: 15px;
+  background: rgba(236, 239, 241, 0.7);
+  border-radius: 3px;
+  padding: 0px 5px;
+  font-family: monospace;
+  border: 1px solid #ECEFF1;
+  display: inline-block;
+  margin: 0px;
+  margin-bottom: 3px;
+  line-height: 20px;
+}
+#markdown dl dd {
+  margin-bottom: 20px;
+  line-height: 22px;
+  font-size: 15px;
+  padding-left: 5px;
+}
+#markdown pre {
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
+  padding: 20px 30px;
+  margin: 0px;
+  background: rgba(236, 239, 241, 0.5);
+  margin-bottom: 40px;
+  overflow-y: auto;
+}
+#markdown pre code {
+  background: transparent;
+  font-size: 14px;
+  font-weight: normal;
+  font-family: monospace;
+  line-height: 20px;
+  padding: 0px;
+  display: block;
+}
+#markdown pre + pre {
+  margin-top: -30px;
+}
+#markdown strong {
+  font-weight: bold;
+}
+#markdown img {
+  max-width: 100%;
+}
+#markdown img[alt="github oauth setup"] {
+  max-height: 500px;
+  border: 1px solid #EEE;
+  padding: 20px;
+}
+#markdown h1 {
+  font-size: 28px;
+  line-height: 48px;
+  border-top: 1px solid #EEE;
+  padding-top: 10px;
+  margin-top: 40px;
+  margin-bottom: 30px;
+}
+#markdown a,
+#markdown a:visited {
+  color: #3F51B5;
+  text-decoration: none;
+}
+#markdown > p:first-child {
+  margin-top: 0px;
+  padding-top: 0px;
+}
+#markdown > h1:first-child {
+  margin-top: 0px;
+  border-top: 0px;
+  padding-top: 0px;
+}
+@media (max-width: 800px) {
+  #markdown {
+    padding: 0px 20px;
+  }
+}
+.home {
+  background: #f5f5f5;
+}
+.index section article:first-child {
+  margin-top: 40px;
+  border-top: 0px;
+}
+.algolia-autocomplete {
+  display: block !important;
+}
+body.index main header p {
+  max-width: 380px;
+}
+body.tour section {
+  display: flex;
+  max-width: 100%;
+  margin: 0px;
+}
+body.tour section article {
+  width: 400px;
+  min-width: 400px;
+  max-width: 400px;
+  box-sizing: border-box;
+}
+body.tour section article .inner {
+  margin-right: 20px;
+  background: #FFF;
+  box-sizing: border-box;
+  padding: 20px 20px 20px 20px;
+}
+body.tour section div {
+  flex: 1 1 auto;
+  box-sizing: border-box;
+}
+body.tour section div img {
+  width: 100%;
+  border: 1px solid #EEE;
+  box-shadow: 5px 5px 40px rgba(0, 0, 0, 0.1), -5px -5px 40px rgba(0, 0, 0, 0.1);
+}
+body.tour main {
+  padding: 40px;
+}
+body.tour .button-prev,
+body.tour .button-next {
+  display: inline-block;
+  background: #00BFA5;
+  color: #FFF;
+  text-decoration: none;
+  margin-right: 5px;
+  border-radius: 2px;
+  padding: 5px 15px;
+  font-size: 14px;
+  text-transform: uppercase;
+}
+body.tour .button-prev {
+  color: #999;
+  background: #f5f5f5;
+}


### PR DESCRIPTION
relate drone/drone-plugin-index#254

i pull `http://plugins.drone.io/dist/style.min.css` to `static/dist/`, cause it looks different from `static/style.css` and i don't know if there are other repository dependence `static/style.css`.

if it's just a problem left over by history, i can override it and modify `drone-plugin-index`'s dependencies.

PS: i think the version of `hugo` should be marked in `drone-plugin-index`,it seems to be `0.55.5`, and the latest version does not work on the home page.